### PR TITLE
Improve type resolution for version 0.5 schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "coverage": "vitest run --coverage",
     "check": "tsc && publint",
     "build": "tsc && publint",
+    "prepare": "tsc && publint",
     "fmt": "deno fmt src test"
   },
   "exports": {

--- a/src/0.5.ts
+++ b/src/0.5.ts
@@ -6,13 +6,17 @@ export const VersionSchema = z
   .describe("The version of the OME-Zarr Metadata");
 
 
-function withVersion<T1 extends z.ZodRawShape, T2 extends z.ZodObject<T1>>(InnerSchema: T2) {
-  return z.object({
-    ome: InnerSchema.extend({
-      version: VersionSchema,
+function withVersion<T extends z.ZodRawShape>(InnerSchema: T) {
+  const withVersionSchema = z.object({
+    ome: z.object({
+      ...InnerSchema,
+      version: VersionSchema
     }).describe("The versioned OME-Zarr Metadata namespace"),
   }).describe("The zarr.json attributes key");
+
+  return withVersionSchema
 }
+
 
 // PLATE
 
@@ -147,11 +151,11 @@ function createPlateSchema<T extends z.ZodTypeAny>(Aquisition: T) {
 
 export const PlateSchema = withVersion(z.object({
   plate: createPlateSchema(Aquisition).partial({ name: true }),
-}));
+}).shape);
 
 export const StrictPlateSchema = withVersion(z.object({
   plate: createPlateSchema(StrictAquisition),
-}));
+}).shape);
 
 // BF2Raw
 
@@ -161,7 +165,7 @@ export const Bf2RawSchema = withVersion(z.object({
     .describe(
       "The top-level identifier metadata added by bioformats2raw"
     ),
-}));
+}).shape);
 
 // OME
 
@@ -171,7 +175,7 @@ export const OmeSchema = withVersion(z.object({
     .describe(
       "An array of the same length and the same order as the images defined in the OME-XML"
     )
-}));
+}).shape);
 
 // Image
 
@@ -294,9 +298,9 @@ function createImageSchema<T extends z.ZodTypeAny>(Multiscale: T) {
   });
 }
 
-export const ImageSchema = withVersion(createImageSchema(Multiscale));
+export const ImageSchema = withVersion(createImageSchema(Multiscale).shape);
 
-export const StrictImageSchema = withVersion(createImageSchema(StrictMultiscale));
+export const StrictImageSchema = withVersion(createImageSchema(StrictMultiscale).shape);
 
 // Label
 
@@ -350,11 +354,11 @@ const ImageLabelSchema = StrictImageLabelSchema.partial({
 
 export const LabelSchema = withVersion(z.object({
   "image-label": ImageLabelSchema
-}));
+}).shape);
 
 export const StrictLabelSchema = withVersion(z.object({
   "image-label": StrictImageLabelSchema
-}));
+}).shape);
 
 // Well
 
@@ -386,15 +390,16 @@ const StrictInnerWellSchema = z.object({
     }),
 });
 
+
 export const WellSchema = withVersion(z.object({
-  well: StrictInnerWellSchema.partial({ })
-}));
+  well: StrictInnerWellSchema.partial({})
+}).shape);
 
 export const StrictWellSchema = withVersion(z.object({
   well: StrictInnerWellSchema
-}));
+}).shape);
 
-export const OmeZarrSchema = z.union([ 
+export const OmeZarrSchema = z.union([
   Bf2RawSchema,
   ImageSchema,
   ImageLabelSchema,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,22 @@
 {
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "compilerOptions": {
     "outDir": "dist",
     "module": "node16",
     "moduleResolution": "node16",
     "moduleDetection": "force",
     "target": "ES2020", // Node.js 14
-    "lib": ["ES2020"],
+    "lib": [
+      "ES2020"
+    ],
     "declaration": true,
     "pretty": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": [
+      "node"
+    ]
   }
 }


### PR DESCRIPTION
Generic types in withVersion function were erasing the InnerSchema type, meaning consumers of the package could only see that objects parsed using one of these schemas had ome and ome.version attributes, completely losing all typing for the actual schema itself.

The proposed solution uses simpler generics in combination with object spread syntax, rather than using zod's .extend method. This is an approved method in the zod documentation: https://zod.dev/api?id=extend#extend and comes with a number of advantages over the .extend, including faster type resolution.

PR also includes 2 incidental changes:

Provides a 'prepare' command to allow installation via GitHub directly (in principle this can be removed from the PR, I am using it to take advantage of these changes from my fork, but I can't see the harm of keeping it).
Prevents typescript from resolving all global https://github.com/types, which was causing issues with https://github.com/types in node_modules within parent directories when building the package. "node" Should be sufficient for this project but this will need to be updated if additional dependencies with globally defined types are added.